### PR TITLE
Also map additional GiftcardProgram properties from the StaticMapper

### DIFF
--- a/src/StaticMappers/Giftcards/GiftcardProgramMapper.php
+++ b/src/StaticMappers/Giftcards/GiftcardProgramMapper.php
@@ -12,7 +12,10 @@ class GiftcardProgramMapper
         return new GiftcardProgram(
             $data->uuid,
             $data->name,
-            $data->active ?? true
+            $data->active ?? true,
+            $data->max_amount_in_cents ?? null,
+            $data->calculator_flow ?? null,
+            $data->expiration_days ?? null
         );
     }
 }


### PR DESCRIPTION
I missed this in #35 -- there are also static versions of all the mappers that need to implement the additional properties.