### PR TITLE
Add methods to get Giftcard by its UUID

### DIFF
--- a/src/Models/Giftcards/Giftcard.php
+++ b/src/Models/Giftcards/Giftcard.php
@@ -124,6 +124,18 @@ class Giftcard
      *
      * @throws MaintenanceModeException|GuzzleException|PiggyRequestException
      */
+    public static function get(string $giftcardUuid, array $params = []): Giftcard
+    {
+        $response = ApiClient::get(self::resourceUri."/$giftcardUuid", $params);
+
+        return GiftcardMapper::map($response->getData());
+    }
+
+    /**
+     * @param  mixed[]  $params
+     *
+     * @throws MaintenanceModeException|GuzzleException|PiggyRequestException
+     */
     public static function findOneBy(array $params): Giftcard
     {
         $response = ApiClient::get(self::resourceUri.'/find-one-by', $params);

--- a/src/Resources/OAuth/Giftcards/GiftcardsResource.php
+++ b/src/Resources/OAuth/Giftcards/GiftcardsResource.php
@@ -17,6 +17,18 @@ class GiftcardsResource extends BaseResource
     /**
      * @throws PiggyRequestException
      */
+    public function get(string $giftcardUuid): Giftcard
+    {  
+        $response = $this->client->get("$this->resourceUri/$giftcardUuid");
+
+        $mapper = new GiftcardMapper();
+
+        return $mapper->map($response->getData());
+    }
+
+    /**
+     * @throws PiggyRequestException
+     */
     public function findOneBy(string $hash): Giftcard
     {
         $response = $this->client->get("$this->resourceUri/find-one-by", [

--- a/tests/OAuth/Giftcards/GiftcardsResourceTest.php
+++ b/tests/OAuth/Giftcards/GiftcardsResourceTest.php
@@ -11,6 +11,42 @@ class GiftcardsResourceTest extends OAuthTestCase
     /**
      * @test
      *
+     * @throws GuzzleException
+     * @throws PiggyRequestException
+     * @throws MaintenanceModeException
+     */
+    public function it_gets_a_giftcard()
+    {
+        $this->addExpectedResponse([
+            'uuid' => '00a8878d-5d51-405f-a0c0-34e1863785f1',
+            'hash' => 'FOOBAR',
+            'amount_in_cents' => 321,
+            'type' => 'DIGITAL',
+            'active' => true,
+            'upgradeable' => false,
+            'expiration_date' => '2130-06-13T12:09:00+00:00',
+            'giftcard_program' => [
+                'name' => 'My Giftcards',
+                'active' => 'true',
+                'uuid' => 'ea7c5a55-1df5-45cc-868e-343947b6b3b4',
+            ],
+        ]);
+
+        $giftcard = $this->mockedClient->giftcards->get('00a8878d-5d51-405f-a0c0-34e1863785f1');
+
+        $this->assertEquals('00a8878d-5d51-405f-a0c0-34e1863785f1', $giftcard->getUuid());
+        $this->assertEquals('FOOBAR', $giftcard->getHash());
+        $this->assertEquals(321, $giftcard->getAmountInCents());
+        $this->assertEquals('DIGITAL', GiftcardType::byValue($giftcard->getType())->getName());
+        $this->assertEquals(true, $giftcard->isActive());
+        $this->assertEquals(false, $giftcard->isUpgradeable());
+        $this->assertEquals('ea7c5a55-1df5-45cc-868e-343947b6b3b4', $giftcard->getGiftcardProgram()->getUuid());
+        $this->assertEquals('My Giftcards', $giftcard->getGiftcardProgram()->getName());
+    }
+
+    /**
+     * @test
+     *
      * @throws PiggyRequestException
      */
     public function it_finds_a_giftcard_by_hash()
@@ -30,7 +66,7 @@ class GiftcardsResourceTest extends OAuthTestCase
             ],
         ]);
 
-        $giftcard = $this->mockedClient->giftcards->findOneBy('GJ2P725oe');
+        $giftcard = $this->mockedClient->giftcards->get('123-123');
 
         $this->assertEquals('123-123', $giftcard->getUuid());
         $this->assertEquals('GJ2P725oe', $giftcard->getHash());


### PR DESCRIPTION
Pending the release of the api/v3/register/giftcards/giftcardUuid GET endpoint, this PR adds the necessary calls to the SDK