### PR TITLE
Add paginated voucher list

### DIFF
--- a/src/Mappers/BasePaginatedMapper.php
+++ b/src/Mappers/BasePaginatedMapper.php
@@ -66,6 +66,8 @@ abstract class BasePaginatedMapper
 
     /**
      * Get the pagination links
+     *
+     * @return mixed[]
      */
     public function getLinks(): array
     {

--- a/src/Mappers/BasePaginatedMapper.php
+++ b/src/Mappers/BasePaginatedMapper.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Piggy\Api\Mappers;
+
+abstract class BasePaginatedMapper
+{
+    /**
+     * @var mixed[]
+     */
+    public $data;
+
+    /**
+     * @var mixed[]
+     */
+    public $meta;
+
+    /**
+     * @param  mixed[]  $data
+     * @param  mixed[]  $meta
+     */
+    public function __construct(array $data, array $meta)
+    {
+        $this->data = $data;
+        $this->meta = $meta;
+    }
+
+    /**
+     * Get the mapped data
+     *
+     * @return mixed[]
+     */
+    abstract public function getData(): array;
+
+    /**
+     * @return mixed[]
+     */
+    public function getMeta(): array
+    {
+        return $this->meta;
+    }
+
+    /**
+     * Get the current page
+     */
+    public function getCurrentPage(): int
+    {
+        return $this->getMeta()['current_page'];
+    }
+
+
+    /**
+     * Get the starting item number
+     */
+    public function getFrom(): int
+    {
+        return $this->getMeta()['from'];
+    }
+
+    /**
+     * Get the last page
+     */
+    public function getLastPage(): int
+    {
+        return $this->getMeta()['last_page'];
+    }
+
+    /**
+     * Get the pagination links
+     */
+    public function getLinks(): array
+    {
+        return $this->getMeta()['links'];
+    }
+
+    /**
+     * Get the current path
+     */
+    public function getPath(): string
+    {
+        return $this->getMeta()['path'];
+    }
+
+    /**
+     * Get the items per page count
+     */
+    public function getPerPage(): int
+    {
+        return $this->getMeta()['per_page'];
+    }
+
+    /**
+     * Get the ending item number
+     */
+    public function getTo(): int
+    {
+        return $this->getMeta()['to'];
+    }
+
+    /**
+     * Get the total count
+     */
+    public function getTotal(): int
+    {
+        return $this->getMeta()['total'];
+    }
+}

--- a/src/Mappers/Vouchers/PaginatedVouchersMapper.php
+++ b/src/Mappers/Vouchers/PaginatedVouchersMapper.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Piggy\Api\Mappers\Vouchers;
+
+use Piggy\Api\Mappers\BasePaginatedMapper;
+use Piggy\Api\Models\Vouchers\Voucher;
+
+class PaginatedVouchersMapper extends BasePaginatedMapper
+{
+    /**
+     * Get the mapped vouchers
+     *
+     * @return Voucher[]
+     */
+    public function getData(): array
+    {
+        $mapper = new VoucherMapper();
+        $vouchers = [];
+
+        foreach ($this->data as $item) {
+            $vouchers[] = $mapper->map($item);
+        }
+
+        return $vouchers;
+    }
+}

--- a/src/Models/Vouchers/Voucher.php
+++ b/src/Models/Vouchers/Voucher.php
@@ -216,7 +216,6 @@ class Voucher
 
     /**
      * @param  mixed[]  $params
-     * @return Voucher[]
      *
      * @throws MaintenanceModeException|GuzzleException|PiggyRequestException
      */

--- a/src/Models/Vouchers/Voucher.php
+++ b/src/Models/Vouchers/Voucher.php
@@ -8,6 +8,7 @@ use Piggy\Api\ApiClient;
 use Piggy\Api\Exceptions\MaintenanceModeException;
 use Piggy\Api\Exceptions\PiggyRequestException;
 use Piggy\Api\Models\Contacts\Contact;
+use Piggy\Api\Mappers\Vouchers\PaginatedVouchersMapper;
 use Piggy\Api\StaticMappers\Vouchers\VoucherLockMapper;
 use Piggy\Api\StaticMappers\Vouchers\VoucherMapper;
 use Piggy\Api\StaticMappers\Vouchers\VouchersMapper;
@@ -211,6 +212,25 @@ class Voucher
         $response = ApiClient::get(self::resourceUri, $params);
 
         return VouchersMapper::map((array) $response->getData());
+    }
+
+    /**
+     * @param  mixed[]  $params
+     * @return Voucher[]
+     *
+     * @throws MaintenanceModeException|GuzzleException|PiggyRequestException
+     */
+    public static function paginatedList(int $page = 1, int $limit = 30, array $params = []): PaginatedVouchersMapper
+    {
+        $response = ApiClient::get(
+            self::resourceUri,
+            array_merge($params, ['page' => $page, 'limit' => $limit])
+        );
+
+        return new PaginatedVouchersMapper(
+            (array) $response->getData(),
+            (array) $response->getMeta()
+        );
     }
 
     /**

--- a/src/Resources/Shared/Vouchers/BaseVouchersResource.php
+++ b/src/Resources/Shared/Vouchers/BaseVouchersResource.php
@@ -4,6 +4,7 @@ namespace Piggy\Api\Resources\Shared\Vouchers;
 
 use DateTime;
 use Piggy\Api\Exceptions\PiggyRequestException;
+use Piggy\Api\Mappers\Vouchers\PaginatedVouchersMapper;
 use Piggy\Api\Mappers\Vouchers\VoucherLockMapper;
 use Piggy\Api\Mappers\Vouchers\VoucherMapper;
 use Piggy\Api\Mappers\Vouchers\VouchersMapper;
@@ -49,6 +50,25 @@ abstract class BaseVouchersResource extends BaseResource
         $mapper = new VouchersMapper();
 
         return $mapper->map((array) $response->getData());
+    }
+
+    /**
+     * @throws PiggyRequestException
+     */
+    public function paginatedList(int $page = 1, int $limit = 30, ?string $promotionUuid = null, ?string $contactUuid = null, ?string $status = null): PaginatedVouchersMapper
+    {
+        $response = $this->client->get($this->resourceUri, [
+            'page' => $page,
+            'limit' => $limit,
+            'promotion_uuid' => $promotionUuid,
+            'contact_uuid' => $contactUuid,
+            'status' => $status,
+        ]);
+
+        return new PaginatedVouchersMapper(
+            (array) $response->getData(),
+            (array) $response->getMeta()
+        );
     }
 
     /**


### PR DESCRIPTION
This PR makes it possible to use and retrieve pagination details for the voucher list endpoint.

## Usage example:
### OAuth / Register API:
```php
$list = $client->voucher->paginatedList($page, $limit);

// Get the vouchers
$vouchers = $list->getData();

// Get the last page
$lastPage = $list->getLastPage();
```

### OAuth with static classes:
```php
$list = Voucher::paginatedList($page, $limit);

// Get the vouchers
$vouchers = $list->getData();

// Get the last page
$lastPage = $list->getLastPage();
```