### PR TITLE
Add Media mapping to Promotion object

### DIFF
--- a/src/Mappers/Vouchers/PromotionMapper.php
+++ b/src/Mappers/Vouchers/PromotionMapper.php
@@ -28,7 +28,7 @@ class PromotionMapper
             $attributes ?? [],
             $data->type,
             $data->redemptions_per_voucher,
-            $media ?? null,
+            $media ?? null
         );
     }
 }

--- a/src/Mappers/Vouchers/PromotionMapper.php
+++ b/src/Mappers/Vouchers/PromotionMapper.php
@@ -2,6 +2,7 @@
 
 namespace Piggy\Api\Mappers\Vouchers;
 
+use Piggy\Api\Mappers\Loyalty\MediaMapper;
 use Piggy\Api\Models\Vouchers\Promotion;
 use stdClass;
 

--- a/src/Mappers/Vouchers/PromotionMapper.php
+++ b/src/Mappers/Vouchers/PromotionMapper.php
@@ -13,6 +13,10 @@ class PromotionMapper
             $attributes = get_object_vars($data->attributes);
         }
 
+        if (isset($data->media)) {
+            $media = (new MediaMapper)->map($data->media);
+        }
+
         return new Promotion(
             $data->uuid,
             $data->name,
@@ -22,7 +26,8 @@ class PromotionMapper
             $data->expiration_duration ?? null,
             $attributes ?? [],
             $data->type,
-            $data->redemptions_per_voucher
+            $data->redemptions_per_voucher,
+            $media ?? null,
         );
     }
 }

--- a/src/Models/Vouchers/Promotion.php
+++ b/src/Models/Vouchers/Promotion.php
@@ -79,7 +79,8 @@ class Promotion
         ?int $expiration_duration = null,
         array $attributes = [],
         ?string $type = null,
-        ?int $redemptions_per_voucher = null
+        ?int $redemptions_per_voucher = null,
+        ?Media $media = null
     ) {
         $this->uuid = $uuid;
         $this->name = $name;
@@ -90,6 +91,7 @@ class Promotion
         $this->attributes = $attributes;
         $this->type = $type;
         $this->redemptions_per_voucher = $redemptions_per_voucher;
+        $this->media = $media;
     }
 
     public function getName(): string

--- a/src/Models/Vouchers/Promotion.php
+++ b/src/Models/Vouchers/Promotion.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Exception\GuzzleException;
 use Piggy\Api\ApiClient;
 use Piggy\Api\Exceptions\MaintenanceModeException;
 use Piggy\Api\Exceptions\PiggyRequestException;
+use Piggy\Api\Models\Loyalty\Media;
 use Piggy\Api\StaticMappers\Vouchers\PromotionMapper;
 use Piggy\Api\StaticMappers\Vouchers\PromotionsMapper;
 
@@ -55,6 +56,11 @@ class Promotion
      * @var mixed[]
      */
     protected $attributes;
+
+    /**
+     * @var Media|null
+     */
+    protected $media;
 
     /**
      * @var string
@@ -132,6 +138,11 @@ class Promotion
     public function getAttributes(): array
     {
         return $this->attributes;
+    }
+
+    public function getMedia(): ?Media
+    {
+        return $this->media;
     }
 
     /**

--- a/src/StaticMappers/Vouchers/PromotionMapper.php
+++ b/src/StaticMappers/Vouchers/PromotionMapper.php
@@ -2,6 +2,7 @@
 
 namespace Piggy\Api\StaticMappers\Vouchers;
 
+use Piggy\Api\Mappers\Loyalty\MediaMapper;
 use Piggy\Api\Models\Vouchers\Promotion;
 
 class PromotionMapper
@@ -14,6 +15,10 @@ class PromotionMapper
             $attributes = get_object_vars($data->attributes);
         }
 
+        if (isset($data->media)) {
+            $media = (new MediaMapper)->map($data->media);
+        }
+
         return new Promotion(
             $data->uuid,
             $data->name,
@@ -23,7 +28,8 @@ class PromotionMapper
             $data->expiration_duration ?? null,
             isset($data->attributes) ? $attributes : [],
             $data->type,
-            $data->redemptions_per_voucher
+            $data->redemptions_per_voucher,
+            $media ?? null
         );
     }
 }


### PR DESCRIPTION
The API exposes media as a property of the Promotion object, but this is not mapped in the PHP SDK yet.

Closes https://github.com/leat-api/piggy-php-sdk/issues/52